### PR TITLE
Auto-crop margins option using AdjustWindowRectEx

### DIFF
--- a/CropMargins.cs
+++ b/CropMargins.cs
@@ -30,5 +30,8 @@ namespace CropperDeck {
 			Right = right;
 			Bottom = bottom;
 		}
-	}
+
+        // just so we don't have a hardcoded string in 5 different places
+        public static readonly string AutoCropName = "Auto";
+    }
 }

--- a/DeckColumn.cs
+++ b/DeckColumn.cs
@@ -24,6 +24,7 @@ namespace CropperDeck {
 		public ToolStripTextBox TfName;
 		public DeckWindow Window = null;
 		public CropMargins CropMargins = CropMargins.Zero;
+        public bool ShouldAutoCrop = false;
 		public Panel WindowCtr;
 		public ToolStripSpringLabel TlName;
 		public Point OverlaySize = new Point(0, 0);
@@ -120,6 +121,7 @@ namespace CropperDeck {
 			TbPadding.DisplayStyle = ToolStripItemDisplayStyle.Image;
 			TmPadding_Build();
 		}
+
 		public void TmPadding_Build() {
 			TbPadding.DropDownItems.Clear();
 			foreach (var m in MainForm.CropMargins) {
@@ -129,12 +131,21 @@ namespace CropperDeck {
 				tb.Width = 80;
 				tb.Click += (object sender, EventArgs e) => {
 					CropMargins = m;
+                    ShouldAutoCrop = false; // window should not auto-crop
 					Window?.Update();
 					MainForm.FlushConfig();
 				};
 				TbPadding.DropDownItems.Add(tb);
 			}
-		}
+
+            var tbAuto = new ToolStripButton("Auto-Crop\u2122");
+            tbAuto.Click += (sender, args) => {
+                ShouldAutoCrop = true; // window should auto-crop, see DeckWindow.GetAutoCropMargins()
+                Window?.Update();
+            };
+            TbPadding.DropDownItems.Add(tbAuto);
+        }
+
 		private void TbConfig_Init() {
 			TbConfig = new ToolStripDropDownButton("Edit...", Resources.pencil);
 			TbConfig.DisplayStyle = ToolStripItemDisplayStyle.Image;

--- a/DeckColumn.cs
+++ b/DeckColumn.cs
@@ -142,6 +142,7 @@ namespace CropperDeck {
             tbAuto.Click += (sender, args) => {
                 ShouldAutoCrop = true; // window should auto-crop, see DeckWindow.GetAutoCropMargins()
                 Window?.Update();
+                MainForm.FlushConfig();
             };
             TbPadding.DropDownItems.Add(tbAuto);
         }

--- a/DeckState.cs
+++ b/DeckState.cs
@@ -34,10 +34,16 @@ namespace CropperDeck {
 			foreach (var m in form.CropMargins) Margins.Add(m);
 			foreach (var pan in form.GetDeckColumns()) {
 				var cm = pan.CropMargins;
-				var cmName = cm.Name;
-				if (!MarginsContainName(Margins, cmName) && !MarginsContainName(HiddenMargins, cmName)) {
-					HiddenMargins.Add(cm);
-				}
+                string cmName;
+                if (pan.ShouldAutoCrop) {
+                    cmName = CropMargins.AutoCropName;
+                }
+                else {
+                    cmName = cm.Name;
+                    if (!MarginsContainName(Margins, cmName) && !MarginsContainName(HiddenMargins, cmName)) {
+                        HiddenMargins.Add(cm);
+                    }
+                }
 				var cd = new ColumnData();
 				cd.Name = pan.ColumnName;
 				cd.Icon = pan.IconName;
@@ -56,13 +62,20 @@ namespace CropperDeck {
 			form.PanCtr.SuspendLayout();
 			foreach (var panState in Columns) {
 				var pan = new DeckColumn(form);
-				var cm = Margins.Where(m => m.Name == panState.CropStyle).FirstOrDefault();
-				if (cm.Name == null) {
-					cm = HiddenMargins.Where(m => m.Name == panState.CropStyle).FirstOrDefault();
-					if (cm.Name == null) cm = CropMargins.Zero;
-				}
-				pan.CropMargins = cm;
-				pan.TfName.Text = pan.TlName.Text = pan.ColumnName = panState.Name;
+                if (panState.CropStyle == CropMargins.AutoCropName) {
+                    pan.ShouldAutoCrop = true;
+                }
+                else {
+                    var cm = Margins.Where(m => m.Name == panState.CropStyle).FirstOrDefault();
+                    if (cm.Name == null)
+                    {
+                        cm = HiddenMargins.Where(m => m.Name == panState.CropStyle).FirstOrDefault();
+                        if (cm.Name == null) cm = CropMargins.Zero;
+                    }
+                    pan.CropMargins = cm;
+                    pan.ShouldAutoCrop = false;
+                }
+                pan.TfName.Text = pan.TlName.Text = pan.ColumnName = panState.Name;
 				if (panState.Icon != "") {
 					pan.IconName = panState.Icon;
 					if (File.Exists(pan.IconPath)) {

--- a/DeckWindow.cs
+++ b/DeckWindow.cs
@@ -10,7 +10,12 @@ namespace CropperDeck {
 		public DeckColumn Column;
 		public IntPtr Handle;
 		public WinAPI_Rect OrigRect = new WinAPI_Rect();
-		public CropMargins CropMargins { get => Column.CropMargins; }
+		public CropMargins CropMargins {
+            get => (Column.ShouldAutoCrop)
+                ? GetAutoCropMargins()
+                : Column.CropMargins;
+        }
+
 		public DeckWindow(IntPtr hwnd, DeckColumn col) {
 			Handle = hwnd;
 			Column = col;
@@ -36,5 +41,18 @@ namespace CropperDeck {
 				width + CropMargins.Left + CropMargins.Right,
 				height + CropMargins.Top + CropMargins.Bottom);
 		}
+
+        // get margins from winapi based on the current window styles (should crop just the client area)
+        private CropMargins GetAutoCropMargins()
+        {
+            uint style = (uint) WinAPI.GetWindowLong(Handle, WinAPI_GWL.GWL_STYLE);
+            uint exStyle = (uint) WinAPI.GetWindowLong(Handle, WinAPI_GWL.GWL_EXSTYLE);
+
+            WinAPI_Rect rect = new WinAPI_Rect(0, 0, 0, 0);  // we just want margins, so adjusted rect is 0
+            WinAPI.AdjustWindowRectEx(ref rect, style, false, exStyle);
+
+            // AdjustWindowRectEx adjusts the rect outwards, so left and top are negative
+            return new CropMargins("Auto", -rect.Left, -rect.Top, rect.Right, rect.Bottom);
+        }
 	}
 }

--- a/DeckWindow.cs
+++ b/DeckWindow.cs
@@ -52,7 +52,7 @@ namespace CropperDeck {
             WinAPI.AdjustWindowRectEx(ref rect, style, false, exStyle);
 
             // AdjustWindowRectEx adjusts the rect outwards, so left and top are negative
-            return new CropMargins("Auto", -rect.Left, -rect.Top, rect.Right, rect.Bottom);
+            return new CropMargins(CropMargins.AutoCropName, -rect.Left, -rect.Top, rect.Right, rect.Bottom);
         }
 	}
 }

--- a/Tools/WinAPI.cs
+++ b/Tools/WinAPI.cs
@@ -22,6 +22,9 @@ namespace CropperDeck {
 		[DllImport("user32.dll", SetLastError = true)]
 		public static extern bool GetWindowRect(IntPtr hwnd, out WinAPI_Rect lpRect);
 
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern bool GetClientRect(IntPtr hwnd, out WinAPI_Rect lpRect);
+
 		[DllImport("user32.dll", SetLastError = true)]
 		public static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
 
@@ -46,7 +49,35 @@ namespace CropperDeck {
 		public static IntPtr FindWindowByTitle(string title) {
 			return FindWindow(null, title);
 		}
+
+        [DllImport("user32.dll", SetLastError = true, EntryPoint = "GetWindowLong")]
+        private static extern IntPtr GetWindowLong32(IntPtr hWnd, int nIndex);
+
+        [DllImport("user32.dll", SetLastError = true, EntryPoint = "GetWindowLongPtr")]
+        private static extern IntPtr GetWindowLongPtr64(IntPtr hWnd, int nIndex);
+
+        public static IntPtr GetWindowLong(IntPtr hWnd, int nIndex)
+        {
+            return (IntPtr.Size == 4)
+                ? GetWindowLong32(hWnd, nIndex)
+                : GetWindowLongPtr64(hWnd, nIndex);
+        }
+
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern bool AdjustWindowRectEx(ref WinAPI_Rect lpRect, uint dwStyle, bool bMenu, uint dwExStyle);
 	}
+
+    public static class WinAPI_GWL
+    {
+        public static readonly int
+        GWL_WNDPROC = -4,
+        GWL_HINSTANCE = -6,
+        GWL_HWNDPARENT = -8,
+        GWL_STYLE = -16,
+        GWL_EXSTYLE = -20,
+        GWL_USERDATA = -21,
+        GWL_ID = -12;
+    }
 
 	public static class WinAPI_SWP {
 		public static IntPtr
@@ -73,6 +104,13 @@ namespace CropperDeck {
 	}
 	[StructLayout(LayoutKind.Sequential)]
 	public struct WinAPI_Rect {
+        public WinAPI_Rect(int left, int top, int right, int bottom)
+        {
+            Left = left;
+            Top = top;
+            Right = right;
+            Bottom = bottom;
+        }
 		public int Left, Top, Right, Bottom;
 		public int Width { get => Right - Left; }
 		public int Height { get => Bottom - Top; }


### PR DESCRIPTION
Hi, here's a quick implementation of auto-crop. It detects the current size of window borders, title bar and other non-client elements using the AdjustWindowRectEx function.

It's not flawless, and the results can be a bit weird for applications using DwmExtendFrameIntoClientArea or otherwise drawing their own borders, but it should work for most Win32 apps and result in perfectly cropped borders regardless of the user's Windows theme and metrics settings.

I added it to the config file reader/writer as well, though you may want to refactor it a bit so it doesn't cause a collision should the user define a regular margin preset named "Auto" (I ran out of spoons to do that myself, sorry)