### PR TITLE
Add devcontainer configuration files

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,25 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+FROM mono:6
+
+ENV DEBIAN_FRONTEND=noninteractive
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN apt-get update \
+	&& apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+	&& apt-get -y install git openssh-client less iproute2 procps lsb-release \
+	&& groupadd --gid $USER_GID $USERNAME \
+	&& useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
+	&& apt-get install -y sudo \
+	&& echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
+	&& chmod 0440 /etc/sudoers.d/$USERNAME \
+	&& apt-get autoremove -y \
+	&& apt-get clean -y \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV DEBIAN_FRONTEND=dialog

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+	"name": "Debian",
+	"dockerFile": "Dockerfile",
+	"features": {},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"EditorConfig.EditorConfig",
+				"ms-dotnettools.csharp"
+			],
+			"settings": {
+				"omnisharp.useModernNet": false
+			}
+		}
+	},
+	"postAttachCommand": {
+		"fix-git": "git config --global --add safe.directory /workspaces/Deck",
+		"add-packages": "nuget restore"
+	}
+}


### PR DESCRIPTION
Add devcontainer files allowing the project to be built without MSVC installed. The repo can be opened in VSCode (or other compatible IDEs) and then launched into a Docker container with all necessary packages. After building the binaries are accessible outside the container.

Pretty minimal config, using the upstream Mono image with minor tweaks to make it more devcontainer-friendly.